### PR TITLE
fix(backend): Fix failing e2e tests on TC

### DIFF
--- a/src/git/git.service.ts
+++ b/src/git/git.service.ts
@@ -46,8 +46,6 @@ export class GitService {
       switchMap(() => from(this.git.addConfig('branch.autsetupmerge', 'true'))),
       switchMap(() => from(this.git.addConfig('branch.autsetuprebase', 'always'))),
       switchMap(() => from(this.git.addConfig('pull.rebase', 'true'))),
-      switchMap(() => from(this.git.addConfig('core.whitespace',
-        '-space-before-tab,-indent-with-no-tab,-tab-in-indent,-trailing-space'))),
       map(() => { return; }),
     );
   }

--- a/src/git/git.service.ts
+++ b/src/git/git.service.ts
@@ -43,6 +43,8 @@ export class GitService {
       switchMap(() => from(this.git.addConfig('commit.gpgSign', 'false'))),
       switchMap(() => from(this.git.addConfig('core.whitespace',
         '-space-before-tab,-indent-with-no-tab,-tab-in-indent,-trailing-space'))),
+      switchMap(() => from(this.git.addConfig('branch.autsetupmerge', 'true'))),
+      switchMap(() => from(this.git.addConfig('branch.autsetuprebase', 'always'))),
       map(() => { return; }),
     );
   }
@@ -92,8 +94,11 @@ export class GitService {
     if (remoteName) {
       options.push(`--origin=${remoteName}`);
     }
+    if (!remoteName) {
+      remoteName = 'origin';
+    }
 
-    const notesRef = remoteName ? `remote.${remoteName}.fetch` : 'remote.origin.fetch';
+    const notesRef = `remote.${remoteName}.fetch`;
 
     trace(`clone remoteUrl: ${remoteUrl}, localPath: ${localPath}, options: ${options}`);
     const parentDir = path.dirname(localPath);
@@ -103,7 +108,7 @@ export class GitService {
       switchMap(() => from(this.git.cwd(localPath))),
       switchMap(() => this.addDefaultConfig()),
       switchMap(() => from(this.git.raw(['config', '--add', notesRef, '+refs/notes/*:refs/notes/*']))),
-      switchMap(() => from(this.git.fetch(remoteName ? remoteName : 'origin'))),
+      switchMap(() => from(this.git.fetch(remoteName))),
       mapTo(localPath),
     );
   }

--- a/src/git/git.service.ts
+++ b/src/git/git.service.ts
@@ -41,6 +41,8 @@ export class GitService {
     return from(this.git.addConfig('user.name', gitKdoUserName)).pipe(
       switchMap(() => from(this.git.addConfig('user.email', gitKdoEmail))),
       switchMap(() => from(this.git.addConfig('commit.gpgSign', 'false'))),
+      switchMap(() => from(this.git.addConfig('core.whitespace',
+        '-space-before-tab,-indent-with-no-tab,-tab-in-indent,-trailing-space'))),
       map(() => { return; }),
     );
   }
@@ -140,7 +142,7 @@ export class GitService {
     return from(this.git.cwd(repoDir)).pipe(
       map(() => patchFile),
       tap(file => trace(`importing ${file}`)),
-      flatMap(file => from(this.git.raw(['am', file]))),
+      flatMap(file => from(this.git.raw(['am', '--ignore-whitespace', file]))),
       map(() => { /* void */ }),
       takeLast(1),
     );

--- a/src/git/git.service.ts
+++ b/src/git/git.service.ts
@@ -45,6 +45,9 @@ export class GitService {
         '-space-before-tab,-indent-with-no-tab,-tab-in-indent,-trailing-space'))),
       switchMap(() => from(this.git.addConfig('branch.autsetupmerge', 'true'))),
       switchMap(() => from(this.git.addConfig('branch.autsetuprebase', 'always'))),
+      switchMap(() => from(this.git.addConfig('pull.rebase', 'true'))),
+      switchMap(() => from(this.git.addConfig('core.whitespace',
+        '-space-before-tab,-indent-with-no-tab,-tab-in-indent,-trailing-space'))),
       map(() => { return; }),
     );
   }

--- a/src/git/git.service.ts
+++ b/src/git/git.service.ts
@@ -43,8 +43,9 @@ export class GitService {
       switchMap(() => from(this.git.addConfig('commit.gpgSign', 'false'))),
       switchMap(() => from(this.git.addConfig('core.whitespace',
         '-space-before-tab,-indent-with-no-tab,-tab-in-indent,-trailing-space'))),
-      switchMap(() => from(this.git.addConfig('branch.autsetupmerge', 'true'))),
-      switchMap(() => from(this.git.addConfig('branch.autsetuprebase', 'always'))),
+      switchMap(() => from(this.git.addConfig('branch.autosetupmerge', 'true'))),
+      switchMap(() => from(this.git.addConfig('branch.autosetuprebase', 'always'))),
+      switchMap(() => from(this.git.addConfig('branch.master.rebase', 'true'))),
       switchMap(() => from(this.git.addConfig('pull.rebase', 'true'))),
       map(() => { return; }),
     );
@@ -94,8 +95,7 @@ export class GitService {
     }
     if (remoteName) {
       options.push(`--origin=${remoteName}`);
-    }
-    if (!remoteName) {
+    } else {
       remoteName = 'origin';
     }
 

--- a/src/git/git.service.ts
+++ b/src/git/git.service.ts
@@ -30,7 +30,7 @@ export class GitService {
         if (command) {
           debug(`calling: git ${command}`);
           stdout.pipe(process.stdout);
-          stderr.pipe(process.stderr);
+          stderr.pipe(process.stdout);
         }
       });
     }

--- a/test/projects.e2e-spec.ts
+++ b/test/projects.e2e-spec.ts
@@ -325,7 +325,11 @@ describeIf('ProjectsController (e2e)', canRunTheseTests(), () => {
       git('config user.email kdo@example.com', repoDir);
       git('config commit.gpgSign false', repoDir);
       git('config --add remote.origin.fetch +refs/notes/*:refs/notes/*', repoDir);
+      git('config branch.autosetupmerge true', repoDir);
+      git('config branch.autosetuprebase always', repoDir);
       git('config branch.master.rebase true', repoDir);
+      git('config pull.rebase true', repoDir);
+      git('config core.whitespace -space-before-tab,-indent-with-no-tab,-tab-in-indent,-trailing-space', repoDir);
     }
 
     async function cloneLocalKeyboardsRepo(): Promise<string> {

--- a/test/projects.e2e-spec.ts
+++ b/test/projects.e2e-spec.ts
@@ -325,6 +325,7 @@ describeIf('ProjectsController (e2e)', canRunTheseTests(), () => {
       git('config user.email kdo@example.com', repoDir);
       git('config commit.gpgSign false', repoDir);
       git('config --add remote.origin.fetch +refs/notes/*:refs/notes/*', repoDir);
+      git('config branch.master.rebase true', repoDir);
     }
 
     async function cloneLocalKeyboardsRepo(): Promise<string> {

--- a/test/projects.e2e-spec.ts
+++ b/test/projects.e2e-spec.ts
@@ -304,7 +304,7 @@ describeIf('ProjectsController (e2e)', canRunTheseTests(), () => {
 
       // clone single keyboard repo
       git(`clone https://github.com/${user}/test_kdo_khmer_angkor ${cloneDir}`, tmpDir);
-      git('config --add remote.origin.fetch +refs/notes/*:refs/notes/*', cloneDir);
+      addDefaultConfiguration(cloneDir);
       git('fetch -p origin', cloneDir);
 
       // reset to backup branch and amend HEAD commit to remove git notes which might be there
@@ -318,13 +318,22 @@ describeIf('ProjectsController (e2e)', canRunTheseTests(), () => {
       git(`-c "http.extraheader=Authorization: ${token}" push --force origin master`, cloneDir);
     });
 
+    function addDefaultConfiguration(
+      repoDir: string
+    ): void {
+      git('config user.name "Keyman Developer Online e2e tests"', repoDir);
+      git('config user.email kdo@example.com', repoDir);
+      git('config commit.gpgSign false', repoDir);
+      git('config --add remote.origin.fetch +refs/notes/*:refs/notes/*', repoDir);
+    }
+
     async function cloneLocalKeyboardsRepo(): Promise<string> {
       const kbDir = path.join(tmpDir, configService.keyboardsRepoName);
 
       // clone keyboards repo
       if (!await fileExists(kbDir).toPromise()) {
         git(`clone https://github.com/${user}/${configService.keyboardsRepoName} ${kbDir}`, tmpDir);
-        git('config --add remote.origin.fetch +refs/notes/*:refs/notes/*', kbDir);
+        addDefaultConfiguration(kbDir);
       }
       git('fetch -p origin', kbDir);
       return kbDir;


### PR DESCRIPTION
We need to set username and email and some other settings for the repos that we clone as
part of setting up the e2e tests. The build agents on TC don't have those settings in the global config.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/keymanapp/developer.keyman.com/66)
<!-- Reviewable:end -->
